### PR TITLE
config: Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+<!-- 
+
+The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]
+
+- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
+- Other [TYPE]s WILL NOT be included in release change logs. 
+- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 
+
+-->
+
+This PR addresses [ISSUE_LINK]


### PR DESCRIPTION
This PR:

- Adds a pull request template based on the one the GUI team had been using on Gitea. 