### PR TITLE
Update labels on templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Use this template for reporting a bug. A bug is an unexpected problem or unintended behavior that breaks functionality. However, UX improvements should be documented as an enhancement.
-labels: 03 - Low
+labels: triage
 title: "[FEATURE SCOPE]: [BUG TITLE]"
 type: Bug
 ---

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -8,27 +8,19 @@ type: Bug
 
 <!--
 # Instructions
-Labels for change type and priority are automatically assigned at the time of creation. 
-**The default priority is Low. Please change the priority label if this requires more attention.**
 
-Here are suggestions to help you set the correct priority but changes can be made at your discretion.
+PLEASE DO NOT SET ASSIGNEE, PRIORITY, LABELS, OR MILESTONE!!!
+Please complete the template below. DO NOT DELETE!
 
-If this bug is related to:
-- lying about data
-- core functionality that is broken
-please set the priority to Critical.
-
-If this bug is related to:  
-  - Current series objectives
-  - Next major release objectives
-  - Impacting or Requested by multiple customers
-please set the priority to High.
-
-If this bug does not meet the above criteria but is more important,
-please set the priority to Medium. 
 -->
 
 # Bug Report
+
+Before opening a bug report, please complete the following checklist:
+- [ ] Check the documentation for intended behavior, notes, warnings, and edge cases
+- [ ] Check open AND closed issues to see if this is a duplicate
+	- A closed duplicate issue may exist if this is a wontfix
+
 
 ## What are the steps to reproduce this issue?
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,7 +1,7 @@
 ---
 name: Documentation
 about: Use this template for documentation needs.
-labels: 03 - Low
+labels: triage
 title: "[FEATURE SCOPE]: [TITLE]"
 type: Documentation
 ---

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -8,21 +8,16 @@ type: Documentation
 
 <!--
 # Instructions
-Labels for change type and priority are automatically assigned at the time of creation. 
-**The default priority is Low. Please change the priority label if this requires more attention.**
 
-Here are suggestions to help you set the correct priority but changes can be made at your discretion.
+PLEASE DO NOT SET ASSIGNEE, PRIORITY, LABELS, OR MILESTONE!!!
+Please complete the template below. DO NOT DELETE!
 
-If this task is related to:  
-  - Current series objectives
-  - Next major release objectives
-please set the priority to High.
-
-If this task does not meet the above criteria but is more important,
-please set the priority to Medium. 
 -->
 
 # Documentation
+
+Before opening a request for documentation, please complete the following checklist:
+- [ ] Check to see if this is a duplicate
 
 ## What needs to be documented?
 

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,7 +1,7 @@
 ---
 name: Enhancement
 about: Use this template for requesting an enhancement. An enhancement is an improvement or extension of an existing feature. Enhancements should be used to document UX improvements.
-labels: 03 - Low
+labels: triage
 title: "[FEATURE SCOPE]: [TITLE]"
 type: Enhancement
 ---

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -7,23 +7,17 @@ type: Enhancement
 ---
 
 <!--
-## Instructions
-Labels for change type and priority are automatically assigned at the time of creation. 
-**The default priority is Low. Please change the priority label if this requires more attention.**
+# Instructions
 
-Here are suggestions to help you set the correct priority but changes can be made at your discretion.
+PLEASE DO NOT SET ASSIGNEE, PRIORITY, LABELS, OR MILESTONE!!!
+Please complete the template below. DO NOT DELETE!
 
-If this request is related to:  
-  - Current series objectives
-  - Next major release objectives
-  - Impacting or Requested by multiple customers
-please set the priority to High.
-
-If this request does not meet the above criteria but is more important,
-please set the priority to Medium. 
 -->
 
 # Enhancement
+
+Before opening an enhancement request, please complete the following checklist:
+- [ ] Check to see if this is a duplicate
 
 ## What is the enhancement to be made?
 

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -7,19 +7,17 @@ type: Epic
 ---
 
 <!--
-## Instructions
-Labels for change type and priority are automatically assigned at the time of creation. 
-**The default priority is Low. Please change the priority label if this requires more attention.**
+# Instructions
 
-Here are suggestions to help you set the correct priority but changes can be made at your discretion.
+PLEASE DO NOT SET ASSIGNEE, PRIORITY, LABELS, OR MILESTONE!!!
+Please complete the template below. DO NOT DELETE!
 
-If this epic describes a major release objective,
-please set the priority to High.
-
-If this describes a secondary release objective,
-please set the priority to Medium. 
 -->
+
 # Epic
+
+Before opening an epic, please complete the following checklist:
+- [ ] Check to see if this is a duplicate
 
 ## Overview
 

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,7 +1,7 @@
 ---
 name: Epic
 about: Use this template for an epic. An epic is used to document a task list that must be accomplished in order to complete a project or a larger goal 
-labels: 03 - Low
+labels: triage
 title: "[FEATURE SCOPE]: [TITLE]"
 type: Epic
 ---

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Use this template for requesting a new feature. This template should be used to request a new feature or functionality that does not currently exist in the application.
-labels: 03 - Low
+labels: triage
 title: "[FEATURE SCOPE]: [TITLE]"
 type: Feature
 ---

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -7,22 +7,17 @@ type: Feature
 ---
 
 <!--
-## Instructions
-Labels for change type and priority are automatically assigned at the time of creation. 
-**The default priority is Low. Please change the priority label if this requires more attention.**
+# Instructions
 
-Here are suggestions to help you set the correct priority but changes can be made at your discretion.
+PLEASE DO NOT SET ASSIGNEE, PRIORITY, LABELS, OR MILESTONE!!!
+Please complete the template below. DO NOT DELETE!
 
-If this request is related to:  
-  - Current series objectives
-  - Next major release objectives
-  - Impacting or Requested by multiple customers
-please set the priority to High.
-
-If this request does not meet the above criteria but is more important,
-please set the priority to Medium. 
 -->
+
 # Feature
+
+Before opening a feature request, please complete the following checklist:
+- [ ] Check to see if this is a duplicate
 
 ## What is the feature to be added?
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -7,21 +7,17 @@ type: Task
 ---
 
 <!--
-## Instructions
-Labels for change type and priority are automatically assigned at the time of creation. 
-**The default priority is Low. Please change the priority label if this requires more attention.**
+# Instructions
 
-Here are suggestions to help you set the correct priority but changes can be made at your discretion.
+PLEASE DO NOT SET ASSIGNEE, PRIORITY, LABELS, OR MILESTONE!!!
+Please complete the template below. DO NOT DELETE!
 
-If this task is related to:  
-  - Current series objectives
-  - Next major release objectives
-please set the priority to High.
-
-If this task does not meet the above criteria but is more important,
-please set the priority to Medium. 
 -->
+
 # Task
+
+Before opening a task, please complete the following checklist:
+- [ ] Check to see if this is a duplicate
 
 ## What needs to be done?
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,7 +1,7 @@
 ---
 name: Task
 about: Use this template for a task. A task should be used for refactoring, automated testing, configuration changes, or other supporting tasks that are not directly related to product development.
-labels: 03 - Low
+labels: triage
 title: "[FEATURE SCOPE]: [TITLE]"
 type: Task
 ---


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no issue. 
Update the org level issue templates.

If you have other improvement suggestions, please let me know. I really want to make this useful to you all.