### PR TITLE
chore: Improve PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,21 @@ The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_M
 -->
 
 This PR addresses [ISSUE_LINK]
+
+## This PR proposes...
+
+-
+
+## PR Tasks
+
+<!-- Add tasks to this list as needed -->
+
+- [ ] e2e and/or unit tests provided. If not, please provide an explanation.
+- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).
+
+## Reviewer Tasks
+
+<!-- Add tasks to this list as needed -->
+
+- [ ] e2e or unit tests are present to test the proposed changes.
+- [ ] Code is sufficiently documented.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,3 +27,4 @@ This PR addresses [ISSUE_LINK]
 
 - [ ] e2e or unit tests are present to test the proposed changes.
 - [ ] Code is sufficiently documented.
+- [ ] Code meets quality and correctness expectations.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ This PR addresses [ISSUE_LINK]
 
 <!-- Add tasks to this list as needed -->
 
-- [ ] e2e and/or unit tests provided. If not, please provide an explanation.
+- [ ] e2e and/or unit tests included. If not, please provide an explanation.
 - [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).
 
 ## Reviewer Tasks


### PR DESCRIPTION
Added sections for PR proposals and tasks for reviewers.

<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses https://github.com/gravwell/issues/issues/2010